### PR TITLE
fixed conflict with min/max macro on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 if(WIN32)
-    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR)
+    add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DNOMINMAX)
     set(MODE WIN32)
 elseif(UNIX)
     add_definitions(-DVK_USE_PLATFORM_XCB_KHR)


### PR DESCRIPTION
I'm not quite sure where the conflict is taking place but this only happens in vsgQt. Looks like the general consensus is to just disable the macro completely via ```NOMINMAX```.