### PR TITLE
Changed CMake files to support Qt6 on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,13 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(vsg 0.1.6 REQUIRED)
-find_package(vsgXchange) # only used by exanples
-find_package(Qt5 5.10 COMPONENTS Widgets REQUIRED)
+find_package(vsgXchange) # only used by examples
+
+if(APPLE)
+    find_package(Qt6 COMPONENTS Widgets REQUIRED)
+else()
+    find_package(Qt5 5.10 COMPONENTS Widgets REQUIRED)
+endif()
 
 vsg_setup_build_vars()
 vsg_setup_dir_vars()
@@ -50,8 +55,10 @@ set(CMAKE_AUTOUIC ON)
 if(WIN32)
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR)
     set(MODE WIN32)
-elseif(UNIX)
+elseif(UNIX AND NOT APPLE)
     add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
+elseif(APPLE)
+    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 else()
     add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
 endif()

--- a/src/vsgQt/CMakeLists.txt
+++ b/src/vsgQt/CMakeLists.txt
@@ -62,11 +62,20 @@ target_include_directories(vsgQt
         $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(vsgQt
-    PUBLIC
-        Qt5::Widgets
-        vsg::vsg
-)
+
+if(APPLE)
+    target_link_libraries(vsgQt
+        PUBLIC
+            Qt6::Widgets
+            vsg::vsg
+    )
+else()
+    target_link_libraries(vsgQt
+        PUBLIC
+            Qt5::Widgets
+            vsg::vsg
+    )
+endif()
 
 if(vsgXchange_FOUND)
     target_link_libraries(vsgQt PRIVATE vsgXchange::vsgXchange)


### PR DESCRIPTION
<img width="1295" alt="Screenshot 2021-09-16 at 11 02 39" src="https://user-images.githubusercontent.com/6074172/133587719-31d0d66f-fabf-4f3a-85ec-51402eff6481.png">

Hi Robert, it's not perfect and crashes on resizing (or ends with exit code 0 :-)) but it starts and the window can be moved.

I never managed to compile Qt5 with enabled Vulkan support on macOS, it seems to be somewhat hard. There are some blog entries by Qt developers how to do that, but none of them worked for me. Qt6 compiles out-of-the-box on macOS with installed LunarG SDK.

I'm not sure whether it is worth or not to merge these changes but something like this would be required, especially

```cmake
elseif(UNIX AND NOT APPLE)
    add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
elseif(APPLE)
    add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
else()
```
since it tries to include XCB headers otherwise.