### PR TITLE
Passing proper button events to mouse events

### DIFF
--- a/src/vsgQt/ViewerWindow.cpp
+++ b/src/vsgQt/ViewerWindow.cpp
@@ -318,7 +318,7 @@ void ViewerWindow::mouseMoveEvent(QMouseEvent* e)
     default: button = 0; break;
     }
 
-    windowAdapter->bufferedEvents.emplace_back(new vsg::MoveEvent(windowAdapter, event_time, e->x(), e->y(), (vsg::ButtonMask)button));
+    windowAdapter->bufferedEvents.emplace_back(new vsg::MoveEvent(windowAdapter, event_time, e->x(), e->y(), static_cast<vsg::ButtonMask>(button)));
 }
 
 void ViewerWindow::mousePressEvent(QMouseEvent* e)
@@ -339,7 +339,7 @@ void ViewerWindow::mousePressEvent(QMouseEvent* e)
     default: button = 0; break;
     }
 
-    windowAdapter->bufferedEvents.emplace_back(new vsg::ButtonPressEvent(windowAdapter, event_time, e->x(), e->y(), (vsg::ButtonMask)button, 0));
+    windowAdapter->bufferedEvents.emplace_back(new vsg::ButtonPressEvent(windowAdapter, event_time, e->x(), e->y(), static_cast<vsg::ButtonMask>(button), static_cast<uint32_t>(e->button())));
 }
 
 void ViewerWindow::mouseReleaseEvent(QMouseEvent* e)
@@ -360,7 +360,7 @@ void ViewerWindow::mouseReleaseEvent(QMouseEvent* e)
     default: button = 0; break;
     }
 
-    windowAdapter->bufferedEvents.emplace_back(new vsg::ButtonReleaseEvent(windowAdapter, event_time, e->x(), e->y(), (vsg::ButtonMask)button, 0));
+    windowAdapter->bufferedEvents.emplace_back(new vsg::ButtonReleaseEvent(windowAdapter, event_time, e->x(), e->y(), static_cast<vsg::ButtonMask>(button), static_cast<uint32_t>(e->button())));
 }
 
 void ViewerWindow::moveEvent(QMoveEvent* e)


### PR DESCRIPTION
I noticed when trying to integrate the Intersection example from vsgExamples.

```buttonPressEvent.button``` returns 0 in the following snippet:

```
    void apply(vsg::ButtonPressEvent& buttonPressEvent) override
    {
        lastPointerEvent = &buttonPressEvent;

        if (buttonPressEvent.button == 1)
        {
            interesection(buttonPressEvent);
        }
    }
```

On Windows VSG internally handles mapping the buffered event as follow:

```
bufferedEvents.emplace_back(new vsg::ButtonPressEvent(this, event_time, mx, my, getButtonMask(wParam), getButtonDownEventDetail(msg)));

int getButtonDownEventDetail(UINT buttonMsg)
{
    return buttonMsg == WM_LBUTTONDOWN ? 1 : (buttonMsg == WM_MBUTTONDOWN ? 2 : buttonMsg == WM_RBUTTONDOWN ? 3 : (buttonMsg == WM_XBUTTONDOWN ? 4 : 0)); // need to determine x1, x2
}
```
I'm not sure if my approach is correct or we should be introducing a MouseMap type class as you have with KeyboardMap. This does fix my issue though.