### PR TITLE
Wayland fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ set(VSGQT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE INTERNAL "Root binary d
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(QT_PACKAGE_NAME Qt5 CACHE STRING "Set Qt package name, i.e. Qt5 or Qt6.")
-
 find_package(vsg 1.0.0)
 
 vsg_setup_dir_vars()
@@ -24,7 +22,8 @@ vsg_setup_build_vars()
 
 
 find_package(vsgXchange) # only used by exanples
-find_package(${QT_PACKAGE_NAME} COMPONENTS Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 
 vsg_add_target_clang_format(
     FILES
@@ -66,6 +65,7 @@ elseif(APPLE)
     add_definitions(-DVK_USE_PLATFORM_MACOS_MVK)
 elseif(UNIX)
     add_definitions(-DVK_USE_PLATFORM_XCB_KHR)
+    add_definitions(-DVK_USE_PLATFORM_WAYLAND_KHR)
 else()
     add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
 endif()

--- a/include/vsgQt/ViewerWindow.h
+++ b/include/vsgQt/ViewerWindow.h
@@ -71,9 +71,8 @@ namespace vsgQt
         void wheelEvent(QWheelEvent*) override;
 
         /// convert Qt's window coordinate into Vulkan/VSG ones by scaling by the devicePixelRatio()
-        int32_t convert_coord(int c) const { return static_cast<int32_t>(std::round(static_cast<float>(c) * devicePixelRatio())); }
-        int32_t convert_coord(unsigned int c) const { return static_cast<int32_t>(std::round(static_cast<float>(c) * devicePixelRatio())); }
-        int32_t convert_coord(float c) const { return static_cast<int32_t>(std::round(c * devicePixelRatio())); }
+        template<typename T>
+        int32_t convert_coord(T c) const { return static_cast<int32_t>(std::round(static_cast<qreal>(c) * devicePixelRatio())); }
 
         std::pair<vsg::ButtonMask, uint32_t> convertMouseButtons(QMouseEvent* e) const;
 

--- a/src/vsgQt/CMakeLists.txt
+++ b/src/vsgQt/CMakeLists.txt
@@ -66,7 +66,7 @@ target_include_directories(vsgQt
 )
 target_link_libraries(vsgQt
     PUBLIC
-        ${QT_PACKAGE_NAME}::Widgets
+        Qt${QT_VERSION_MAJOR}::Widgets
         vsg::vsg
 )
 

--- a/src/vsgQt/ViewerWindow.cpp
+++ b/src/vsgQt/ViewerWindow.cpp
@@ -308,8 +308,17 @@ void ViewerWindow::mouseMoveEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    auto position = e->position();
-    windowAdapter->bufferedEvents.push_back(vsg::MoveEvent::create(windowAdapter, event_time, convert_coord(position.x()), convert_coord(position.y()), mask));
+    int32_t x = 0;
+    int32_t y = 0;
+
+#if QT_VERSION_MAJOR == 6
+    x = convert_coord(e->position().x());
+    y = convert_coord(e->position().y());
+#else
+    x = convert_coord(e->x());
+    y = convert_coord(e->y());
+#endif
+    windowAdapter->bufferedEvents.push_back(vsg::MoveEvent::create(windowAdapter, event_time, x, y, mask));
 }
 
 void ViewerWindow::mousePressEvent(QMouseEvent* e)
@@ -320,8 +329,18 @@ void ViewerWindow::mousePressEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    auto position = e->position();
-    windowAdapter->bufferedEvents.push_back(vsg::ButtonPressEvent::create(windowAdapter, event_time, convert_coord(position.x()), convert_coord(position.y()), mask, button));
+    int32_t x = 0;
+    int32_t y = 0;
+
+#if QT_VERSION_MAJOR == 6
+    x = convert_coord(e->position().x());
+    y = convert_coord(e->position().y());
+#else
+    x = convert_coord(e->x());
+    y = convert_coord(e->y());
+#endif
+    windowAdapter->bufferedEvents.push_back(vsg::ButtonPressEvent::create(windowAdapter, event_time, x, y, mask, button));
+
 }
 
 void ViewerWindow::mouseReleaseEvent(QMouseEvent* e)
@@ -332,8 +351,18 @@ void ViewerWindow::mouseReleaseEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    auto position = e->position();
-    windowAdapter->bufferedEvents.push_back(vsg::ButtonReleaseEvent::create(windowAdapter, event_time, convert_coord(position.x()), convert_coord(position.y()), mask, button));
+    int32_t x = 0;
+    int32_t y = 0;
+
+#if QT_VERSION_MAJOR == 6
+    x = convert_coord(e->position().x());
+    y = convert_coord(e->position().y());
+#else
+    x = convert_coord(e->x());
+    y = convert_coord(e->y());
+#endif
+    windowAdapter->bufferedEvents.push_back(vsg::ButtonReleaseEvent::create(windowAdapter, event_time, x, y, mask, button));
+
 }
 
 void ViewerWindow::moveEvent(QMoveEvent*)

--- a/src/vsgQt/ViewerWindow.cpp
+++ b/src/vsgQt/ViewerWindow.cpp
@@ -38,8 +38,12 @@ const char* instanceExtensionSurfaceName()
     return VK_KHR_WIN32_SURFACE_EXTENSION_NAME;
 #elif defined(VK_USE_PLATFORM_XLIB_KHR)
     return VK_KHR_XLIB_SURFACE_EXTENSION_NAME;
-#elif defined(VK_USE_PLATFORM_XCB_KHR)
-    return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
+#elif defined(VK_USE_PLATFORM_XCB_KHR) || defined (VK_USE_PLATFORM_WAYLAND_KHR)
+    auto platform = qGuiApp->platformName();
+    if(platform == "wayland")
+        return VK_KHR_WAYLAND_SURFACE_EXTENSION_NAME;
+    else
+        return VK_KHR_XCB_SURFACE_EXTENSION_NAME;
 #elif defined(VK_USE_PLATFORM_MACOS_MVK)
     return VK_MVK_MACOS_SURFACE_EXTENSION_NAME;
 #endif
@@ -214,7 +218,14 @@ void ViewerWindow::exposeEvent(QExposeEvent* /*e*/)
     if (!_initialized && isExposed())
     {
 #if QT_HAS_VULKAN_SUPPORT
-        if (surfaceType() == QSurface::VulkanSurface)
+        auto platform = qGuiApp->platformName();
+        if(platform == "wayland")
+        {
+            vsg::info("Wayland platform detected, forced using QSurface");
+            setSurfaceType(QSurface::VulkanSurface);
+            intializeUsingAdapterWindow(convert_coord(width()), convert_coord(height()));
+        }
+        else if (surfaceType() == QSurface::VulkanSurface)
         {
             vsg::info("Using QSurface");
             intializeUsingAdapterWindow(convert_coord(width()), convert_coord(height()));
@@ -297,7 +308,8 @@ void ViewerWindow::mouseMoveEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    windowAdapter->bufferedEvents.push_back(vsg::MoveEvent::create(windowAdapter, event_time, convert_coord(e->x()), convert_coord(e->y()), mask));
+    auto position = e->position();
+    windowAdapter->bufferedEvents.push_back(vsg::MoveEvent::create(windowAdapter, event_time, convert_coord(position.x()), convert_coord(position.y()), mask));
 }
 
 void ViewerWindow::mousePressEvent(QMouseEvent* e)
@@ -308,7 +320,8 @@ void ViewerWindow::mousePressEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    windowAdapter->bufferedEvents.push_back(vsg::ButtonPressEvent::create(windowAdapter, event_time, convert_coord(e->x()), convert_coord(e->y()), mask, button));
+    auto position = e->position();
+    windowAdapter->bufferedEvents.push_back(vsg::ButtonPressEvent::create(windowAdapter, event_time, convert_coord(position.x()), convert_coord(position.y()), mask, button));
 }
 
 void ViewerWindow::mouseReleaseEvent(QMouseEvent* e)
@@ -319,7 +332,8 @@ void ViewerWindow::mouseReleaseEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    windowAdapter->bufferedEvents.push_back(vsg::ButtonReleaseEvent::create(windowAdapter, event_time, convert_coord(e->x()), convert_coord(e->y()), mask, button));
+    auto position = e->position();
+    windowAdapter->bufferedEvents.push_back(vsg::ButtonReleaseEvent::create(windowAdapter, event_time, convert_coord(position.x()), convert_coord(position.y()), mask, button));
 }
 
 void ViewerWindow::moveEvent(QMoveEvent*)

--- a/src/vsgQt/ViewerWindow.cpp
+++ b/src/vsgQt/ViewerWindow.cpp
@@ -189,7 +189,7 @@ void ViewerWindow::intializeUsingAdapterWindow(uint32_t width, uint32_t height)
         delete vulkanInstance;
     }
 #else
-    vsg::info("ViewerWindow::intializeUsingAdapterWindow(", width, ", ", height, ") not supported, requires Qt 5.10 or later.");
+    std::cout << "ViewerWindow::intializeUsingAdapterWindow(" << width << ", " << height << ") not supported, requires Qt 5.10 or later." << std::endl;
 #endif
 }
 
@@ -213,7 +213,7 @@ void ViewerWindow::intializeUsingVSGWindow(uint32_t width, uint32_t height)
     windowAdapter = vsg::Window::create(traits);
 }
 
-void ViewerWindow::exposeEvent(QExposeEvent* /*e*/)
+void ViewerWindow::exposeEvent(QExposeEvent* e)
 {
     if (!_initialized && isExposed())
     {
@@ -258,7 +258,7 @@ void ViewerWindow::hideEvent(QHideEvent* /*e*/)
     }
 }
 
-void ViewerWindow::resizeEvent(QResizeEvent* /*e*/)
+void ViewerWindow::resizeEvent(QResizeEvent* e)
 {
     if (!windowAdapter) return;
 


### PR DESCRIPTION
Added handle of wayland platform, to run which, instead of XCB extension, you need to specify VK_KHR_WAYLAND_SURFACE_EXTENSION.

From Qt documentation:
_Note: It is up to the component creating the external instance to ensure the necessary extensions are enabled on it. These are: VK_KHR_surface, the WSI-specific VK_KHR_*_surface that is appropriate for the platform in question, and VK_EXT_debug_report in case QVulkanInstance's debug output redirection is desired._

Added automatic selection of Q6 instead of Qt5.

Fixed Qt6 warnings about deprecated UI event functions.

Tested on 5.15 and 6.2.2 Qt.