### PR TITLE
Fixed Qt6 warnings, added Qt6 auto detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,6 @@ set(VSGQT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE INTERNAL "Root binary d
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(QT_PACKAGE_NAME Qt5 CACHE STRING "Set Qt package name, i.e. Qt5 or Qt6.")
-
 find_package(vsg 1.0.0)
 
 vsg_setup_dir_vars()
@@ -24,7 +22,8 @@ vsg_setup_build_vars()
 
 
 find_package(vsgXchange) # only used by exanples
-find_package(${QT_PACKAGE_NAME} COMPONENTS Widgets REQUIRED)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Widgets REQUIRED)
 
 vsg_add_target_clang_format(
     FILES

--- a/include/vsgQt/ViewerWindow.h
+++ b/include/vsgQt/ViewerWindow.h
@@ -71,9 +71,8 @@ namespace vsgQt
         void wheelEvent(QWheelEvent*) override;
 
         /// convert Qt's window coordinate into Vulkan/VSG ones by scaling by the devicePixelRatio()
-        int32_t convert_coord(int c) const { return static_cast<int32_t>(std::round(static_cast<float>(c) * devicePixelRatio())); }
-        int32_t convert_coord(unsigned int c) const { return static_cast<int32_t>(std::round(static_cast<float>(c) * devicePixelRatio())); }
-        int32_t convert_coord(float c) const { return static_cast<int32_t>(std::round(c * devicePixelRatio())); }
+        template<typename T>
+        int32_t convert_coord(T c) const { return static_cast<int32_t>(std::round(static_cast<qreal>(c) * devicePixelRatio())); }
 
         std::pair<vsg::ButtonMask, uint32_t> convertMouseButtons(QMouseEvent* e) const;
 

--- a/src/vsgQt/CMakeLists.txt
+++ b/src/vsgQt/CMakeLists.txt
@@ -66,7 +66,7 @@ target_include_directories(vsgQt
 )
 target_link_libraries(vsgQt
     PUBLIC
-        ${QT_PACKAGE_NAME}::Widgets
+        Qt${QT_VERSION_MAJOR}::Widgets
         vsg::vsg
 )
 

--- a/src/vsgQt/ViewerWindow.cpp
+++ b/src/vsgQt/ViewerWindow.cpp
@@ -297,7 +297,17 @@ void ViewerWindow::mouseMoveEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    windowAdapter->bufferedEvents.push_back(vsg::MoveEvent::create(windowAdapter, event_time, convert_coord(e->x()), convert_coord(e->y()), mask));
+    int32_t x = 0;
+    int32_t y = 0;
+
+#if QT_VERSION_MAJOR == 6
+    x = convert_coord(e->position().x());
+    y = convert_coord(e->position().y());
+#else
+    x = convert_coord(e->x());
+    y = convert_coord(e->y());
+#endif
+    windowAdapter->bufferedEvents.push_back(vsg::MoveEvent::create(windowAdapter, event_time, x, y, mask));
 }
 
 void ViewerWindow::mousePressEvent(QMouseEvent* e)
@@ -308,7 +318,18 @@ void ViewerWindow::mousePressEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    windowAdapter->bufferedEvents.push_back(vsg::ButtonPressEvent::create(windowAdapter, event_time, convert_coord(e->x()), convert_coord(e->y()), mask, button));
+    int32_t x = 0;
+    int32_t y = 0;
+
+#if QT_VERSION_MAJOR == 6
+    x = convert_coord(e->position().x());
+    y = convert_coord(e->position().y());
+#else
+    x = convert_coord(e->x());
+    y = convert_coord(e->y());
+#endif
+    windowAdapter->bufferedEvents.push_back(vsg::ButtonPressEvent::create(windowAdapter, event_time, x, y, mask, button));
+
 }
 
 void ViewerWindow::mouseReleaseEvent(QMouseEvent* e)
@@ -319,7 +340,18 @@ void ViewerWindow::mouseReleaseEvent(QMouseEvent* e)
 
     auto [mask, button] = convertMouseButtons(e);
 
-    windowAdapter->bufferedEvents.push_back(vsg::ButtonReleaseEvent::create(windowAdapter, event_time, convert_coord(e->x()), convert_coord(e->y()), mask, button));
+    int32_t x = 0;
+    int32_t y = 0;
+
+#if QT_VERSION_MAJOR == 6
+    x = convert_coord(e->position().x());
+    y = convert_coord(e->position().y());
+#else
+    x = convert_coord(e->x());
+    y = convert_coord(e->y());
+#endif
+    windowAdapter->bufferedEvents.push_back(vsg::ButtonReleaseEvent::create(windowAdapter, event_time, x, y, mask, button));
+
 }
 
 void ViewerWindow::moveEvent(QMoveEvent*)


### PR DESCRIPTION
Fixed Qt6 warnings
Automatic Qt selection in CMake. https://doc.qt.io/qt-6/cmake-qt5-and-qt6-compatibility.html
#21 

Tested on Fedora 37, Qt 5.15.8, Qt 6.2.2, Qt 6.4.2