### PR TITLE
Add macOS functionality

### DIFF
--- a/src/vsgQt/CMakeLists.txt
+++ b/src/vsgQt/CMakeLists.txt
@@ -32,10 +32,18 @@ macro(add_library_export_header _TARGET)
     endif()
 endmacro()
 
-set(SOURCES
-    KeyboardMap.cpp
-    ViewerWindow.cpp
-)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set(SOURCES
+        KeyboardMap.cpp
+        makeViewMetalCompatible.mm
+        ViewerWindow.cpp
+    )
+else()
+    set(SOURCES
+        KeyboardMap.cpp
+        ViewerWindow.cpp
+    )
+endif()
 
 set(HEADERS
     ../../include/vsgQt/KeyboardMap.h

--- a/src/vsgQt/ViewerWindow.cpp
+++ b/src/vsgQt/ViewerWindow.cpp
@@ -29,6 +29,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 #include <iostream>
 
+#if defined(__APPLE__)
+    extern "C" { void makeViewMetalCompatible(void* handle); }
+#endif
 
 using namespace vsgQt;
 
@@ -200,7 +203,12 @@ void ViewerWindow::intializeUsingVSGWindow(uint32_t width, uint32_t height)
 #elif defined(VK_USE_PLATFORM_XCB_KHR)
     traits->nativeWindow = static_cast<xcb_window_t>(winId());
 #elif defined(VK_USE_PLATFORM_MACOS_MVK)
-    traits->nativeWindow = reinterpret_cast<NSView*>(winId()); // or NSWindow* ?
+    #if defined(__APPLE__)
+    void* handle = (void*)winId();
+    makeViewMetalCompatible(handle);
+    //traits->nativeWindow = reinterpret_cast<NSView*>(winId()); // or NSWindow* ?
+    traits->nativeWindow = handle;
+    #endif
 #endif
 
     traits->width = width;

--- a/src/vsgQt/makeViewMetalCompatible.mm
+++ b/src/vsgQt/makeViewMetalCompatible.mm
@@ -1,0 +1,19 @@
+//
+// Thanks to:   Ilya Kryukov https://github.com/ikryukov/QtVulkan.git
+//
+#import <Cocoa/Cocoa.h>
+
+#include <QuartzCore/CAMetalLayer.h>
+
+static CALayer* orilayer;
+
+extern "C" void makeViewMetalCompatible(void* handle) {
+  NSView* view = (NSView*)handle;
+  assert([view isKindOfClass:[NSView class]]);
+
+  if (![view.layer isKindOfClass:[CAMetalLayer class]]) {
+    orilayer = [view layer];
+    [view setLayer:[CAMetalLayer layer]];
+    //[view setWantsLayer:NO];
+  }
+}


### PR DESCRIPTION
Building vsgQt on the Mac needs some changes. A obj-c helper function is provided, to make the window handle usable. Should not effect other systems than macOS.
