### PR TITLE
Make building examples optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(vsgQt
     DESCRIPTION "Qt integration with VulkanSceneGraph"
     LANGUAGES CXX
 )
+
+option(VSGQT_BUILD_EXMAPLES "Build examples" ON)
+
 set(VSGQT_SOVERSION 3)
 set(VSGQT_RELEASE_CANDIDATE 0)
 
@@ -21,8 +24,6 @@ find_package(vsg 1.1.2)
 
 vsg_setup_dir_vars()
 vsg_setup_build_vars()
-
-find_package(vsgXchange) # only used by examples
 
 # if Qt5 then we need 5.10 or later
 find_package(${QT_PACKAGE_NAME} COMPONENTS Widgets REQUIRED)
@@ -66,6 +67,8 @@ if(WIN32)
 endif()
 
 add_subdirectory(src/vsgQt)
-add_subdirectory(examples)
+if (VSGQT_BUILD_EXMAPLES)
+    add_subdirectory(examples)
+endif()
 
 vsg_add_feature_summary()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(vsgXchange CONFIG REQUIRED)
+
 add_subdirectory(vsgqtviewer)
 add_subdirectory(vsgqtmdi)
 add_subdirectory(vsgqtwindows)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(vsgXchange CONFIG REQUIRED)
+find_package(vsgXchange CONFIG)
 
 add_subdirectory(vsgqtviewer)
 add_subdirectory(vsgqtmdi)


### PR DESCRIPTION
This PR proposes an opt-out approach for building examples, allowing the package to exclude `vsgXchange` as a required dependency when examples are not necessary (e.g., during packaging by package managers).